### PR TITLE
Update tsconfigRootDir to use fixturesDir in tests.js

### DIFF
--- a/rules/tests.js
+++ b/rules/tests.js
@@ -22,7 +22,7 @@ const run = (...args) => {
         projectService: {
           allowDefaultProject: ["*.ts*", "*.js*"],
         },
-        tsconfigRootDir: __dirname,
+        tsconfigRootDir: fixturesDir,
       },
     },
   });


### PR DESCRIPTION
This PR is the same as #3 (and merge into it to see only the diff)

The only difference is `tsconfigRootDir: fixturesDir`, which give me the next error:

> AssertionError [ERR_ASSERTION]: A fatal parsing error occurred: Parsing error: Too many files (>8) have matched the default project.
> 
> Having many files run with the default project is known to cause performance issues and slow down linting.
> 
> ...list of dummy files...
> 
> If you absolutely need more files included, set parserOptions.projectService.maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING to a larger value.
