### PR TITLE
add tsconfig to the fixutes

### DIFF
--- a/rules/enforce-prop-decorator-enum.js
+++ b/rules/enforce-prop-decorator-enum.js
@@ -3,6 +3,7 @@ const { createRule } = require("./rule");
 
 module.exports = createRule({
   name: "enforce-prop-decorator-enum",
+  defaultOptions: [],
   meta: {
     type: "problem",
     docs: {

--- a/rules/fixtures/tsconfig.json
+++ b/rules/fixtures/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+  },
+  "include": ["*.ts", "*.tsx"]
+}

--- a/rules/tests.js
+++ b/rules/tests.js
@@ -19,9 +19,7 @@ const run = (...args) => {
         ecmaFeatures: {
           jsx: true,
         },
-        projectService: {
-          allowDefaultProject: ["*.ts*", "*.js*"],
-        },
+        project: "./tsconfig.json",
         tsconfigRootDir: fixturesDir,
       },
     },
@@ -39,7 +37,7 @@ const useFilename = (filename) => {
   }
 
   return {
-    filename: filePath,
+    filename, //: filePath,
     before: () => fs.writeFileSync(filePath, ""),
     after: () => () => {
       if (fs.existsSync(filePath)) {

--- a/rules/tsconfig.json
+++ b/rules/tsconfig.json
@@ -1,8 +1,0 @@
-{
-    "compilerOptions": {
-      "jsx": "react",
-      "allowJs": true
-    },
-    "include": ["**/*"]
-  }
-  

--- a/rules/unified-filename-rules.js
+++ b/rules/unified-filename-rules.js
@@ -12,6 +12,7 @@ const notAllowedStylesFileNames = [
 
 module.exports = createRule({
   name: "unified-filename-rules",
+  defaultOptions: [],
   meta: {
     type: "problem",
     docs: {


### PR DESCRIPTION
In this change I'm adding a `tsconfig.json` file to the `fixtures` folder, which is also the `tsconfigRootDir`.

The only problem left is that it can't read a `*.tsx` files:

> AssertionError [ERR_ASSERTION]: A fatal parsing error occurred: Parsing error: ESLint was configured to run on `<tsconfigRootDir>/styles.tsx` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
